### PR TITLE
Making the transferable statement less bad

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4341,10 +4341,6 @@ sender.setParameters(params)
             is null.</p>
           </dd>
 
-          <dt>
-            RTCDataChannel implements Transferable
-          </dt>
-
         <dt>RTCDataChannel createDataChannel([TreatNullAs=EmptyString]
         DOMString label, optional RTCDataChannelInit dataChannelDict)
         </dt>
@@ -4667,6 +4663,10 @@ sender.setParameters(params)
           <var>channel</var>.</p>
         </li>
       </ol>
+
+      <dl class="idl" data-merge="RTCDataChannelInit RTCDataChannel"
+          title="RTCDataChannel implements Transferable">
+      </dl>
 
       <dl class="idl" data-merge="RTCDataChannelInit" title=
       "interface RTCDataChannel : EventTarget">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4342,8 +4342,11 @@ sender.setParameters(params)
           </dd>
 
         <dt>RTCDataChannel createDataChannel([TreatNullAs=EmptyString]
-        DOMString label, optional RTCDataChannelInit dataChannelDict)</dt>
-
+        DOMString label, optional RTCDataChannelInit dataChannelDict)
+        </dt>
+       <dt>
+         RTCDataChannel implements Transferable
+       </dt>
         <dd>
           <p>Creates a new <code><a>RTCDataChannel</a></code> object with the
           given label. The <code><a>RTCDataChannelInit</a></code> dictionary
@@ -7750,6 +7753,19 @@ if (sender.dtmf) {
     adversaries that can observe the network, so this has to be
     regarded as public information.</p>
 
+    <section>
+      <h2>Data Channels and Same-Origin Policy</h3>
+      <p>
+        Data Channels can be used to transfer data not only between
+        pages of the same origin but also between pages of different
+        origins. This potentially can be used to bypass existing browser
+        restrictions on mixed content (if one side is an HTTP origin
+        and the other side is an HTTPS origin). This sort of transfer
+        requires the cooperation of both sides, but can be done without
+        the cooperation of the server by using <code>postMessage</code>
+        to move a <code>DataChannel</code> from one origin to another.
+      </p>
+    </section>
   </section><!--section>
     <h2 id="sec-iana">IANA Registrations</h2>
 

--- a/webrtc.html
+++ b/webrtc.html
@@ -4341,12 +4341,13 @@ sender.setParameters(params)
             is null.</p>
           </dd>
 
+          <dt>
+            RTCDataChannel implements Transferable
+          </dt>
+
         <dt>RTCDataChannel createDataChannel([TreatNullAs=EmptyString]
         DOMString label, optional RTCDataChannelInit dataChannelDict)
         </dt>
-       <dt>
-         RTCDataChannel implements Transferable
-       </dt>
         <dd>
           <p>Creates a new <code><a>RTCDataChannel</a></code> object with the
           given label. The <code><a>RTCDataChannelInit</a></code> dictionary

--- a/webrtc.html
+++ b/webrtc.html
@@ -4327,7 +4327,7 @@ sender.setParameters(params)
     data models the behavior of WebSockets [[WEBSOCKETS-API]].</p>
 
     <section>
-      <h3>RTCPeerConnection Interface Extensions</h2>
+      <h3>RTCPeerConnection Interface Extensions</h3>
 
       <p>The Peer-to-peer data API extends the
       <code><a>RTCPeerConnection</a></code> interface as described below.</p>
@@ -7754,7 +7754,7 @@ if (sender.dtmf) {
     regarded as public information.</p>
 
     <section>
-      <h2>Data Channels and Same-Origin Policy</h3>
+      <h2>Data Channels and Same-Origin Policy</h2>
       <p>
         Data Channels can be used to transfer data not only between
         pages of the same origin but also between pages of different

--- a/webrtc.html
+++ b/webrtc.html
@@ -4327,7 +4327,7 @@ sender.setParameters(params)
     data models the behavior of WebSockets [[WEBSOCKETS-API]].</p>
 
     <section>
-      <h3>RTCPeerConnection Interface Extensions</h3>
+      <h3>RTCPeerConnection Interface Extensions</h2>
 
       <p>The Peer-to-peer data API extends the
       <code><a>RTCPeerConnection</a></code> interface as described below.</p>


### PR DESCRIPTION
This is still bad, but at least it looks semi-right.

Let the editors fix it up from here.
